### PR TITLE
make canvasHidden public because it is used in HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "contributors": [
     "Mosh Mage <moshmage@gmail.com> (http://moshmage.gitlab.io)",
     "Christian Görg <goergc@gmx.de> (http://github.com/goergch)"
+    "Christian Görg <goergc@gmx.de> (http://github.com/goergch)",
+    "Sadiq Khoja <sadiqkhoja@gmail.com> (https://github.com/sadiqkhoja)"
   ],
   "keywords": [
     "angular",

--- a/src/qr-scanner.component.ts
+++ b/src/qr-scanner.component.ts
@@ -50,7 +50,7 @@ export class QrScannerComponent implements OnInit, OnDestroy, AfterViewInit {
     public qrCode: QRCode;
     public stream: MediaStream;
     public captureTimeout: any;
-    private  canvasHidden = true;
+    public  canvasHidden = true;
     get isCanvasSupported(): boolean {
         const canvas = this.renderer.createElement('canvas');
         return !!(canvas.getContext && canvas.getContext('2d'));

--- a/src/qr-scanner.component.ts
+++ b/src/qr-scanner.component.ts
@@ -151,6 +151,7 @@ export class QrScannerComponent implements OnInit, OnDestroy, AfterViewInit {
             this.videoElement = this.renderer.createElement('video');
             this.videoElement.setAttribute('autoplay', 'true');
             this.videoElement.setAttribute('muted', 'true');
+            this.videoElement.setAttribute('playsinline','true');
             this.renderer.appendChild(this.videoWrapper.nativeElement, this.videoElement);
         }
         const self = this;


### PR DESCRIPTION
fixes: ERROR in node_modules/angular2-qrscanner/angular2-qrscanner.d.ts.QrScannerComponent.html(4,35): Property 'canvasHidden' is private and only accessible within class 'QrScannerComponent'.