### PR TITLE
fixes iPhone camera freeze issue

### DIFF
--- a/src/qr-scanner.component.ts
+++ b/src/qr-scanner.component.ts
@@ -151,6 +151,7 @@ export class QrScannerComponent implements OnInit, OnDestroy, AfterViewInit {
             this.videoElement = this.renderer.createElement('video');
             this.videoElement.setAttribute('autoplay', 'true');
             this.videoElement.setAttribute('muted', 'true');
+            this.videoElement.setAttribute('playsinline','true');
             this.renderer.appendChild(this.videoWrapper.nativeElement, this.videoElement);
         }
         const self = this;


### PR DESCRIPTION
we need to set playsinline attribute on videoElement otherwise camera just freezes on iPhone. On android this attribute is ignored.

For more information: https://developer.apple.com/documentation/webkit/safari_tools_and_features/delivering_video_content_for_safari#3030250